### PR TITLE
Dockerfile, raiden: Raiden upgraded to master@62f3138.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,31 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 WORKDIR /work
 
 # Install pre-requisites
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 923F6CA9 && \
-    echo "deb http://ppa.launchpad.net/ethereum/ethereum/ubuntu xenial main" \
+RUN apt-get update && apt-get install -y gnupg2 && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 923F6CA9 && \
+    echo "deb http://ppa.launchpad.net/ethereum/ethereum/ubuntu bionic main" \
        >> /etc/apt/sources.list.d/ethereum.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
+            python3.6 \
             git \
             libssl-dev \
             solc && \
     apt-get install -y \
-            python-pip && \
+            python3-pip && \
     rm -rf /var/lib/apt/lists/*
 
 # We use the local Git submodule for the Raiden build.
 COPY raiden/ raiden/
 
 # Build Raiden client
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 RUN cd raiden && \
-    pip install --upgrade -r requirements.txt && \
-    python setup.py develop
+    pip3 install --upgrade -r requirements.txt && \
+    pip3 install setuptools_scm==1.15.0 && \
+    python3 setup.py develop
 
 # Build the client Web UI - seems to be non-functional at the moment.
 #RUN apt-get install -y --no-install-recommends \
@@ -33,5 +37,5 @@ RUN cd raiden && \
 #    apt-get remove curl
 
 EXPOSE 5001 40001
-
-ENTRYPOINT ["/usr/local/bin/raiden"]
+WORKDIR /work/raiden
+ENTRYPOINT ["/usr/local/bin/raiden","--network-id=mainnet"]


### PR DESCRIPTION
The Raiden after v0.3.0 release requires Python3.6+
Upgrade Docker image to Ubuntu 18.04 LTS with Python 3.6.

Upgrade Raiden submodule to master@62f3138

I tested it all manually:

```
> { partner_address: '0xd3F0cfda2Fb1251cc6Bb9cE5beA925824056Fc38',
  channel_address: '0xb149a458d4D1CD27AEa4211C0caf8a9701DF8905',
  state: 'closed',
  token_address: '0x72641d3657375676C326324d6166e0E3cbA38bcE',
  settle_timeout: 30,
  reveal_timeout: 10,
  balance: 50 }
```

...

```
> token.balanceOf(acct0).then(console.log)
Promise {
  <pending>,
  domain: 
   Domain {
     domain: null,
     _events: 
      { removeListener: [Function: updateExceptionCapture],
        newListener: [Function: updateExceptionCapture],
        error: [Function: debugDomainError] },
     _eventsCount: 3,
     _maxListeners: undefined,
     members

> 249950

```

